### PR TITLE
Use UTF-8.

### DIFF
--- a/perlprimer
+++ b/perlprimer
@@ -3,7 +3,7 @@
 # PerlPrimer
 # Designs primers for PCR, Bisulphite PCR, QPCR (Realtime), and Sequencing
 
-# Copyright © 2003-2017, Owen Marshall
+# Copyright Â© 2003-2017, Owen Marshall
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,6 +21,7 @@
 # USA
 
 use strict;
+use utf8;
 
 #---------------#
 # Usage message #
@@ -38,7 +39,7 @@ BEGIN {
 PerlPrimer v$version
 Designs primers for PCR, Bisulphite PCR, QPCR (Realtime), and Sequencing
 
-Copyright © 2003-2017 Owen Marshall\n
+Copyright Â© 2003-2017 Owen Marshall\n
 Usage: perlprimer.pl [file.ppr]\n
 EOT
 		exit 0;
@@ -48,7 +49,7 @@ EOT
 	if ($win_exe) {
 		print <<EOT;
 PerlPrimer v$version 
-Copyright © 2003-2017 Owen Marshall
+Copyright Â© 2003-2017 Owen Marshall
 Designs primers for PCR, Bisulphite PCR, QPCR (Realtime), and Sequencing
 
 This window is required for PerlPrimer to run - 
@@ -86,7 +87,7 @@ BEGIN {
 			
 			# Print warning header if not already printed
 			unless ($warning) {
-				print "PerlPrimer v$version\nCopyright © 2003-2011 Owen Marshall\n\n";
+				print "PerlPrimer v$version\nCopyright Â© 2003-2011 Owen Marshall\n\n";
 				$warning = 1;
 			}
 			
@@ -1331,13 +1332,13 @@ pack_gui('LabFrame', 'Forward primer', 'forward_l', \$page_primerf);
 			nr(\$row_counter[-1],0);
 			pack_gui('Label', 'Tm: ', 'fprimertm', -font=>$gui_font_bold);
 			pack_gui('Label', \$fprimer_tm, 'fprimertm');
-			pack_gui('Label', '°C', 'fprimertm');
+			pack_gui('Label', 'Â°C', 'fprimertm');
 			nr('',0);
-			pack_gui('Label', 'dS°: ', 'fprimerds', -font=>$gui_font_bold);
+			pack_gui('Label', 'dSÂ°: ', 'fprimerds', -font=>$gui_font_bold);
 			pack_gui('Label', \$fprimer_ds, 'fprimerds');
 			pack_gui('Label', 'eu', 'fprimerds');
 			# nr('',0);
-			# pack_gui('Label', "dG°$pd_temperature: ", 'fprimerds');
+			# pack_gui('Label', "dGÂ°$pd_temperature: ", 'fprimerds');
 			# pack_gui('Label', \$fprimer_dg, 'fprimerds');
 			# pack_gui('Label', 'kcal/mol', 'fprimerds');
 		nc(\$col_ref);
@@ -1346,7 +1347,7 @@ pack_gui('LabFrame', 'Forward primer', 'forward_l', \$page_primerf);
 			pack_gui('Label', \$fprimer_len, 'fprimerlen');
 			pack_gui('Label', 'bases', 'fprimerlen');
 			nr('',0);
-			pack_gui('Label', 'dH°: ', 'fprimerdh', -font=>$gui_font_bold);
+			pack_gui('Label', 'dHÂ°: ', 'fprimerdh', -font=>$gui_font_bold);
 			pack_gui('Label', \$fprimer_dh, 'fprimerdh');
 			pack_gui('Label', 'kcal/mol', 'fprimerdh');
 		nc(\$col_ref);
@@ -1355,7 +1356,7 @@ pack_gui('LabFrame', 'Forward primer', 'forward_l', \$page_primerf);
 			pack_gui('Label', \$fprimer_gc, 'fprimergc');
 			pack_gui('Label', '%', 'fprimergc');
 			nr('',0);
-			pack_gui('Label', "dG°$pd_temperature: ", 'fprimerds', -font=>$gui_font_bold);
+			pack_gui('Label', "dGÂ°$pd_temperature: ", 'fprimerds', -font=>$gui_font_bold);
 			pack_gui('Label', \$fprimer_dg, 'fprimerds');
 			pack_gui('Label', 'kcal/mol', 'fprimerds');
 
@@ -1371,13 +1372,13 @@ pack_gui('LabFrame', 'Reverse primer', 'reverse_l', \$page_primerf);
 			nr(\$row_counter[-1],0);
 			pack_gui('Label', 'Tm: ', 'rprimertm', -font=>$gui_font_bold);
 			pack_gui('Label', \$rprimer_tm, 'rprimertm');
-			pack_gui('Label', '°C', 'rprimertm');
+			pack_gui('Label', 'Â°C', 'rprimertm');
 			nr('',0);
-			pack_gui('Label', 'dS°: ', 'rprimerds', -font=>$gui_font_bold);
+			pack_gui('Label', 'dSÂ°: ', 'rprimerds', -font=>$gui_font_bold);
 			pack_gui('Label', \$rprimer_ds, 'rprimerds');
 			pack_gui('Label', 'eu', 'rprimerds');
 			# nr('',0);
-			# pack_gui('Label', "dG°$pd_temperature: ", 'rprimerds');
+			# pack_gui('Label', "dGÂ°$pd_temperature: ", 'rprimerds');
 			# pack_gui('Label', \$rprimer_dg, 'rprimerds');
 			# pack_gui('Label', 'kcal/mol', 'rprimerds');
 		nc(\$col_ref);
@@ -1386,7 +1387,7 @@ pack_gui('LabFrame', 'Reverse primer', 'reverse_l', \$page_primerf);
 			pack_gui('Label', \$rprimer_len, 'rprimerlen');
 			pack_gui('Label', 'bases', 'rprimerlen');
 			nr('',0);
-			pack_gui('Label', 'dH°: ', 'rprimerdh', -font=>$gui_font_bold);
+			pack_gui('Label', 'dHÂ°: ', 'rprimerdh', -font=>$gui_font_bold);
 			pack_gui('Label', \$rprimer_dh, 'rprimerdh');
 			pack_gui('Label', 'kcal/mol', 'rprimerdh');
 		nc(\$col_ref);
@@ -1395,7 +1396,7 @@ pack_gui('LabFrame', 'Reverse primer', 'reverse_l', \$page_primerf);
 			pack_gui('Label', \$rprimer_gc, 'fprimergc');
 			pack_gui('Label', '%', 'fprimergc');
 			nr('',0);
-			pack_gui('Label', "dG°$pd_temperature: ", 'fprimerds', -font=>$gui_font_bold);
+			pack_gui('Label', "dGÂ°$pd_temperature: ", 'fprimerds', -font=>$gui_font_bold);
 			pack_gui('Label', \$rprimer_dg, 'fprimerds');
 			pack_gui('Label', 'kcal/mol', 'fprimerds');
 
@@ -1439,9 +1440,9 @@ pack_gui('LabFrame', 'Primer Tm', 'primer_tm_l', \$page_primer_designf);
 		pack_gui('Entry', \$min_tm_pr, 'mintm', 3);
 		pack_gui('Label', '-');
 		pack_gui('Entry', \$max_tm_pr, 'maxtm', 3);
-		pack_gui('Label', '°C  Difference');
+		pack_gui('Label', 'Â°C  Difference');
 		pack_gui('Entry', \$max_diff_pr, 'maxdiff', 3);
-		pack_gui('Label', '°C');
+		pack_gui('Label', 'Â°C');
 	
 pack_gui('LabFrame', 'Primer Length', 'primer_len_l', \$page_primer_designf);
 	nr(\$packed_widgets{primer_len_l});
@@ -1531,7 +1532,7 @@ pack_gui('LabFrame', 'Primer Tm', 'seq_tm_l', \$page_sequencingf);
 		pack_gui('Entry', \$min_tm_seq, 'smintm', 3);
 		pack_gui('Label', '-');
 		pack_gui('Entry', \$max_tm_seq, 'smaxtm', 3);
-		pack_gui('Label', '°C');
+		pack_gui('Label', 'Â°C');
 
 pack_gui('LabFrame', 'Primer Length', 'seq_len_l', \$page_sequencingf);
 	nr(\$packed_widgets{seq_len_l});
@@ -1563,7 +1564,7 @@ pack_gui('LabFrame', 'Options', 'seq_options_l', \$page_sequencingf);
 	nr('', 0);
 		pack_gui('Checkbutton', 'Exclude self-complimentarity > -', 'exclude_pd_seq', \$exclude_pd_seq);
 		pack_gui('Entry', \$seq_pd_min, 'spdmin', 3);
-		pack_gui('Label', 'dG°37');
+		pack_gui('Label', 'dGÂ°37');
 
 pack_gui('LabFrame', 'Sequence', 'seq_seq_l', \$page_sequencingf);
 	nr(\$packed_widgets{seq_seq_l});
@@ -1605,9 +1606,9 @@ pack_gui('LabFrame', 'Primer Tm', 'bisul_tm_l', \$page_bisul_seqf);
 		pack_gui('Entry', \$min_tm_bs, 'bisul_mintm', 3);
 		pack_gui('Label', '-');
 		pack_gui('Entry', \$max_tm_bs, 'bisul_maxtm', 3);
-		pack_gui('Label', '°C  Difference');
+		pack_gui('Label', 'Â°C  Difference');
 		pack_gui('Entry', \$max_diff_bs, 'bisul_maxdiff', 3);
-		pack_gui('Label', '°C');
+		pack_gui('Label', 'Â°C');
 
 pack_gui('LabFrame', 'Primer Length', 'bisul_len_l', \$page_bisul_seqf);
 	nr(\$packed_widgets{bisul_len_l});
@@ -1690,9 +1691,9 @@ pack_gui('LabFrame', 'Primer Tm', 'qprimer_tm_l', \$page_qpcrf);
 		pack_gui('Entry', \$min_tm_q, 'qmintm', 3);
 		pack_gui('Label', '-');
 		pack_gui('Entry', \$max_tm_q, 'qmaxtm', 3);
-		pack_gui('Label', '°C  Difference');
+		pack_gui('Label', 'Â°C  Difference');
 		pack_gui('Entry', \$max_diff_q, 'qmaxdiff', 3);
-		pack_gui('Label', '°C');
+		pack_gui('Label', 'Â°C');
 
 pack_gui('LabFrame', 'Primer Length', 'qprimer_len_l', \$page_qpcrf);
 	nr(\$packed_widgets{qprimer_len_l});
@@ -3494,7 +3495,7 @@ sub get_tm {
 	$packed_widgets{dim}->insert('end', "Warning: reverse primer run found\n", 'red') if ($rprimer =~ /(C{$run,}|A{$run,}|G{$run,}|T{$run,})/);
 	$packed_widgets{dim}->insert('end', "Warning: reverse primer repeat found\n", 'red') if ($rprimer =~ /(.{2,})\1{$repeat_real,}/);
 
-	$packed_widgets{dim}->insert('end', "Most stable 3' extensible primer-dimers (at $pd_temperature°C), if any\n\n", 'blue');
+	$packed_widgets{dim}->insert('end', "Most stable 3' extensible primer-dimers (at $pd_temperatureÂ°C), if any\n\n", 'blue');
 	
 	my ($pd1, $pd2, $pd3);
 	if ($fprimer && !check_degenerate($fprimer)) {
@@ -3527,7 +3528,7 @@ sub get_tm {
 	}
 	
 	# $pd_full = 1;
-	$packed_widgets{dim}->insert('end', "\nMore stable non-extensible primer-dimers (at $pd_temperature°C), if any\n\n", 'blue');
+	$packed_widgets{dim}->insert('end', "\nMore stable non-extensible primer-dimers (at $pd_temperatureÂ°C), if any\n\n", 'blue');
 	
 	if ($fprimer && !check_degenerate($fprimer)) {
 		primer_dimer($fprimer,$fprimer,1);
@@ -3566,16 +3567,16 @@ sub get_tm {
 		my $primer_text = <<EOT;
 Forward primer: $fprimer
 
-Tm: $fprimer_tm°C\t\tLength: $fprimer_len bases
-dS°: $fprimer_ds eu\t\tdH°: $fprimer_dh kcal/mol
-dG°$pd_temperature: $fprimer_dg kcal/mol
+Tm: $fprimer_tmÂ°C\t\tLength: $fprimer_len bases
+dSÂ°: $fprimer_ds eu\t\tdHÂ°: $fprimer_dh kcal/mol
+dGÂ°$pd_temperature: $fprimer_dg kcal/mol
 
 		
 Reverse primer: $rprimer
 
-Tm: $rprimer_tm°C\t\tLength: $rprimer_len bases
-dS°: $rprimer_ds eu\t\tdH°: $rprimer_dh kcal/mol
-dG°$pd_temperature: $rprimer_dg kcal/mol
+Tm: $rprimer_tmÂ°C\t\tLength: $rprimer_len bases
+dSÂ°: $rprimer_ds eu\t\tdHÂ°: $rprimer_dh kcal/mol
+dGÂ°$pd_temperature: $rprimer_dg kcal/mol
 
 		
 $dimer_text\n
@@ -5401,7 +5402,7 @@ sub info {
 	
 	my $text = <<EOT;
 PerlPrimer v$version
-Copyright © 2003-2017 Owen Marshall\n
+Copyright Â© 2003-2017 Owen Marshall\n
 EOT
 	my $text2 = <<EOT;
 An application to design primers for PCR, Bisulphite PCR, Real-time PCR and Sequencing.
@@ -5544,7 +5545,7 @@ EOT
 	my $text_entropy=<<EOT;
 Entropy corrections for PCR salt conditions are based on:
 
-von Ahsen N, Wittwer CT, Schütz E.  Oligonucleotide Melting Temperatures under PCR Conditions: Nearest-Neighbor Corrections for Mg2+, Deoxynucleotide Triphosphate, and Dimethyl Sulfoxide Concentrations with Comparison to Alternative Empirical Formulas.  Clinical Chemistry.  2001; 47(11):1956-1961
+von Ahsen N, Wittwer CT, SchÃ¼tz E.  Oligonucleotide Melting Temperatures under PCR Conditions: Nearest-Neighbor Corrections for Mg2+, Deoxynucleotide Triphosphate, and Dimethyl Sulfoxide Concentrations with Comparison to Alternative Empirical Formulas.  Clinical Chemistry.  2001; 47(11):1956-1961
 EOT
 		
 	my $text_cpg=<<EOT;
@@ -5853,7 +5854,7 @@ sub prefs {
 		nr();
 			pack_gui('Label', 'Calculate primer-dimer dG at ', 'prefs_dimer_temp');
 			pack_gui('Entry', \$pd_temperature, 'prefs_dimer_temp', 3);
-			pack_gui('Label', '°C');
+			pack_gui('Label', 'Â°C');
 		
 	nr(\$prefs_page_connection_f, 2);
 		nr();


### PR DESCRIPTION
The following patch converts symbols such as copyright, degree and umlaut to the UTF-8 encoding, which is now the default on the vast majority of computers. For this purpose, it enables the `utf8` pragma.